### PR TITLE
Add detekt-test target

### DIFF
--- a/detekt/defs.bzl
+++ b/detekt/defs.bzl
@@ -94,7 +94,7 @@ def _impl(ctx, run_as_test_target):
         action_outputs.append(html_report)
         detekt_arguments.add("--report", "html:{}".format(html_report.path))
 
-    if ctx.attr._txt_report or ctx.attr.test_target:
+    if ctx.attr._txt_report or run_as_test_target:
         txt_report = ctx.actions.declare_file("{}_detekt_report.txt".format(ctx.label.name))
 
         action_outputs.append(txt_report)

--- a/detekt/defs.bzl
+++ b/detekt/defs.bzl
@@ -172,7 +172,7 @@ detekt_test = rule(
 
 def detekt_test_target(name, srcs, **kwargs):
     detekt_test(
-        name = name + "_detekt_test",
+        name = name,
         srcs = srcs,
         **kwargs
     )

--- a/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/Application.java
+++ b/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/Application.java
@@ -25,6 +25,7 @@ public interface Application {
 
         @Override
         public void run(String[] args) {
+            // TODO: handle custom argument parsing when running as one-shot
             ExecutableResult result = executable.execute(args);
 
             if (result instanceof ExecutableResult.Failure) {

--- a/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/Application.java
+++ b/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/Application.java
@@ -30,6 +30,7 @@ public interface Application {
         public void run(String[] args) {
             List<String> rawArgs = Arrays.asList(args);
 
+            // Extract detekt-arguments from params-file if that's being used
             String paramsFilePath = (args.length == 1 && args[0].startsWith("@") && args[0].endsWith(".params")) ? args[0].substring(1) : "";
             if (!paramsFilePath.isEmpty()) {
                 rawArgs = ExecutionUtils.readArgumentsFromFile(paramsFilePath);
@@ -50,8 +51,10 @@ public interface Application {
 
             ExecutableResult result;
             if (!paramsFilePath.isEmpty()) {
+                // Execute detekt using the modified params-file if that's how arguments were being passed in
                 result = executable.execute(args);
             } else {
+                // Execute with detekt-arguments passed-in directly
                 result = executable.execute(detektArgs.toArray(new String[0]));
             }
 
@@ -61,7 +64,7 @@ public interface Application {
                 streams.error().println(result.output());
             }
 
-            // Write the execution result to a file
+            // Write the exit code to a file
             ExecutionUtils.writeExecutionResultToFile(statusCode, executionResultOutputPath);
 
             // Force the exit code to be 0 if detekt is run as a test target
@@ -87,7 +90,6 @@ public interface Application {
 
         @Override
         public void run(String[] args) {
-            // something
             streams.request()
                 .subscribeOn(scheduler)
                 .parallel()

--- a/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/Application.java
+++ b/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/Application.java
@@ -7,6 +7,9 @@ import io.buildfoundation.bazel.detekt.stream.Streams;
 import io.buildfoundation.bazel.detekt.stream.WorkerStreams;
 import io.reactivex.rxjava3.core.Scheduler;
 
+import java.util.Arrays;
+import java.util.List;
+
 public interface Application {
 
     void run(String[] args);
@@ -25,14 +28,30 @@ public interface Application {
 
         @Override
         public void run(String[] args) {
-            // TODO: handle custom argument parsing when running as one-shot
-            ExecutableResult result = executable.execute(args);
+            List<String> rawArgs = Arrays.asList(args);
+            boolean shouldRunAsTestTarget = ExecutionUtils.shouldRunAsTestTarget(rawArgs);
+
+            // Extract the output path of the execution result from the arguments
+            String executionResultOutputPath = ExecutionUtils.getExecutionResultOutputPath(rawArgs);
+
+            // Sanitize the Detekt arguments
+            List<String> detektArgs = ExecutionUtils.sanitizeDetektArguments(rawArgs);
+            ExecutableResult result = executable.execute(detektArgs.toArray(new String[0]));
+            int statusCode = result.statusCode();
 
             if (result instanceof ExecutableResult.Failure) {
                 streams.error().println(result.output());
             }
 
-            platform.exit(result.statusCode());
+            // Write the execution result to a file
+            ExecutionUtils.writeExecutionResultToFile(statusCode, executionResultOutputPath);
+
+            // Force the exit code to be 0 if detekt is run as a test target
+            if (shouldRunAsTestTarget) {
+                statusCode = 0;
+            }
+
+            platform.exit(statusCode);
         }
     }
 

--- a/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/ExecutionUtils.java
+++ b/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/ExecutionUtils.java
@@ -1,0 +1,92 @@
+package io.buildfoundation.bazel.detekt;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class ExecutionUtils {
+    /**
+     * Returns true if run-as-test-target flag is included in arguments
+     */
+    public static boolean shouldRunAsTestTarget(List<String> arguments) {
+        return arguments.contains("--run-as-test-target");
+    }
+
+    /**
+     * Retrieves the output path for the test result from the input arguments.
+     */
+    public static String getExecutionResultOutputPath(List<String> inputArgs) {
+        String outputPath = getArgument(inputArgs, "--execution-result");
+        if (outputPath == null) {
+            System.err.println("File path for execution-result was not set");
+            System.exit(1);
+        }
+        return outputPath;
+    }
+
+    /**
+     * Writes the execution result to a file
+     */
+    public static void writeExecutionResultToFile(Integer exitCode, String executionResultOutputPath) {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(executionResultOutputPath))) {
+            writer.write(String.format("#!/bin/bash\n\nexit %d\n", exitCode));
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Sanitizes the Detekt arguments by excluding certain arguments.
+     */
+    public static List<String> sanitizeDetektArguments(List<String> inputArgs) {
+        Set<String> excludedArgs = new HashSet<>(Arrays.asList("--execution-result", "--run-as-test-target"));
+        return filterOutArgValuePairs(inputArgs, excludedArgs);
+    }
+
+    /**
+     * Filters out specified arguments and their corresponding values from the input argument list.
+     */
+    public static List<String> filterOutArgValuePairs(List<String> args, Set<String> excludeArgs) {
+        List<String> filteredList = new ArrayList<>();
+
+        int index = 0;
+
+        while (index < args.size()) {
+            String value = args.get(index);
+            if (!excludeArgs.contains(value)) {
+                filteredList.add(value);
+            } else {
+                if (!args.get(index + 1).startsWith("--")) {
+                    // Skip the arg-value pair since matching argument was found
+                    index += 1;
+                }
+            }
+            index += 1;
+        }
+
+        return filteredList;
+    }
+
+    /**
+     * Retrieves the value associated with the given argument name from the input arguments list.
+     *
+     * @param inputArgs List of input arguments.
+     * @param argName The name of the argument whose value needs to be fetched.
+     * @return The value associated with the given argument name or null if the argument is not found.
+     */
+    public static String getArgument(List<String> inputArgs, String argName) {
+        try {
+            // Get the index of the argument and return the value at the next index.
+            return inputArgs.get(inputArgs.indexOf(argName) + 1);
+        } catch (IndexOutOfBoundsException ignored) {
+            // Return null if the argument is not found or there's no value after it.
+            return null;
+        }
+    }
+}

--- a/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/ExecutionUtils.java
+++ b/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/ExecutionUtils.java
@@ -39,7 +39,6 @@ public class ExecutionUtils {
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(executionResultOutputPath))) {
             writer.write(String.format("#!/bin/bash\n\nexit %d\n", exitCode));
         } catch (IOException e) {
-            e.printStackTrace();
             throw new RuntimeException(e);
         }
     }

--- a/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/ExecutionUtils.java
+++ b/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/ExecutionUtils.java
@@ -37,7 +37,7 @@ public class ExecutionUtils {
      */
     public static void writeExecutionResultToFile(Integer exitCode, String executionResultOutputPath) {
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(executionResultOutputPath))) {
-            writer.write(String.format("#!/bin/bash\n\nexit %d\n", exitCode));
+            writer.write(String.format("%d", exitCode));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/ExecutionUtils.java
+++ b/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/ExecutionUtils.java
@@ -44,10 +44,9 @@ public class ExecutionUtils {
     }
 
     /**
-     * Reads in arguments from a params file
+     * Read-in arguments from a params-file
      */
     public static List<String> readArgumentsFromFile(String filePath) {
-        // TODO: something
         try {
             Path path = Paths.get(filePath);
             return Files.readAllLines(path);
@@ -59,7 +58,7 @@ public class ExecutionUtils {
     }
 
     /**
-     * Write arguments to a params file
+     * Write arguments to a params-file
      */
     public static void writeArgumentsToFile(List<String> arguments, String filePath) {
         try {

--- a/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/ExecutionUtils.java
+++ b/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/ExecutionUtils.java
@@ -3,6 +3,9 @@ package io.buildfoundation.bazel.detekt;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -38,6 +41,34 @@ public class ExecutionUtils {
         } catch (IOException e) {
             e.printStackTrace();
             throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Reads in arguments from a params file
+     */
+    public static List<String> readArgumentsFromFile(String filePath) {
+        // TODO: something
+        try {
+            Path path = Paths.get(filePath);
+            return Files.readAllLines(path);
+        } catch (IOException e) {
+            System.err.println("An error occurred while reading the params file: " + e.getMessage());
+            System.exit(1);
+        }
+        return null;
+    }
+
+    /**
+     * Write arguments to a params file
+     */
+    public static void writeArgumentsToFile(List<String> arguments, String filePath) {
+        try {
+            Path path = Paths.get(filePath);
+            Files.write(path, arguments);
+        } catch (IOException e) {
+            System.err.println("An error occurred while writing arguments to params file: " + e.getMessage());
+            System.exit(1);
         }
     }
 

--- a/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/execute/WorkerExecutable.java
+++ b/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/execute/WorkerExecutable.java
@@ -1,16 +1,10 @@
 package io.buildfoundation.bazel.detekt.execute;
 
+import io.buildfoundation.bazel.detekt.ExecutionUtils;
 import io.buildfoundation.bazel.detekt.value.WorkRequest;
 import io.buildfoundation.bazel.detekt.value.WorkResponse;
 
-import java.io.BufferedWriter;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * WorkerExecutable interface representing a worker task.
@@ -27,13 +21,13 @@ public interface WorkerExecutable {
 
         @Override
         public WorkResponse execute(WorkRequest request) {
-            boolean shouldRunAsTestTarget = request.arguments.contains("--run-as-test-target");
+            boolean shouldRunAsTestTarget = ExecutionUtils.shouldRunAsTestTarget(request.arguments);
 
             // Extract the output path of the execution result from the arguments
-            String executionResultOutputPath = getExecutionResultOutputPath(request.arguments);
+            String executionResultOutputPath = ExecutionUtils.getExecutionResultOutputPath(request.arguments);
 
             // Sanitize the Detekt arguments
-            List<String> detektArgs = sanitizeDetektArguments(request.arguments);
+            List<String> detektArgs = ExecutionUtils.sanitizeDetektArguments(request.arguments);
 
             // Execute detekt
             ExecutableResult executableResult = executable.execute(detektArgs.toArray(new String[0]));
@@ -45,7 +39,7 @@ public interface WorkerExecutable {
             workResponse.exitCode = executableResult.statusCode();
 
             // Write the execution result to a file
-            writeExecutionResultToFile(workResponse.exitCode, executionResultOutputPath);
+            ExecutionUtils.writeExecutionResultToFile(workResponse.exitCode, executionResultOutputPath);
 
             // Force the exit code to be 0 if detekt is run as a test target
             if (shouldRunAsTestTarget) {
@@ -53,79 +47,6 @@ public interface WorkerExecutable {
             }
 
             return workResponse;
-        }
-
-        /**
-         * Writes the execution result to a file
-         */
-        private static void writeExecutionResultToFile(Integer exitCode, String executionResultOutputPath) {
-            try (BufferedWriter writer = new BufferedWriter(new FileWriter(executionResultOutputPath))) {
-                writer.write(String.format("#!/bin/bash\n\nexit %d\n", exitCode));
-            } catch (IOException e) {
-                e.printStackTrace();
-                throw new RuntimeException(e);
-            }
-        }
-
-        /**
-         * Sanitizes the Detekt arguments by excluding certain arguments.
-         */
-        private static List<String> sanitizeDetektArguments(List<String> inputArgs) {
-            Set<String> excludedArgs = new HashSet<>(Arrays.asList("--execution-result", "--run-as-test-target"));
-            return filterOutArgValuePairs(inputArgs, excludedArgs);
-        }
-
-        /**
-         * Retrieves the output path for the test result from the input arguments.
-         */
-        private static String getExecutionResultOutputPath(List<String> inputArgs) {
-            String outputPath = getArgument(inputArgs, "--execution-result");
-            if (outputPath == null) {
-                System.err.println("File path for execution-result was not set");
-                System.exit(1);
-            }
-            return outputPath;
-        }
-
-        /**
-         * Filters out specified arguments and their corresponding values from the input argument list.
-         */
-        public static List<String> filterOutArgValuePairs(List<String> args, Set<String> excludeArgs) {
-            List<String> filteredList = new ArrayList<>();
-
-            int index = 0;
-
-            while (index < args.size()) {
-                String value = args.get(index);
-                if (!excludeArgs.contains(value)) {
-                    filteredList.add(value);
-                } else {
-                    if (!args.get(index + 1).startsWith("--")) {
-                        // Skip the arg-value pair since matching argument was found
-                        index += 1;
-                    }
-                }
-                index += 1;
-            }
-
-            return filteredList;
-        }
-
-        /**
-         * Retrieves the value associated with the given argument name from the input arguments list.
-         *
-         * @param inputArgs List of input arguments.
-         * @param argName The name of the argument whose value needs to be fetched.
-         * @return The value associated with the given argument name or null if the argument is not found.
-         */
-        private static String getArgument(List<String> inputArgs, String argName) {
-            try {
-                // Get the index of the argument and return the value at the next index.
-                return inputArgs.get(inputArgs.indexOf(argName) + 1);
-            } catch (IndexOutOfBoundsException ignored) {
-                // Return null if the argument is not found or there's no value after it.
-                return null;
-            }
         }
     }
 }

--- a/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/execute/WorkerExecutable.java
+++ b/detekt/wrapper/src/main/java/io/buildfoundation/bazel/detekt/execute/WorkerExecutable.java
@@ -3,6 +3,9 @@ package io.buildfoundation.bazel.detekt.execute;
 import io.buildfoundation.bazel.detekt.value.WorkRequest;
 import io.buildfoundation.bazel.detekt.value.WorkResponse;
 
+import java.io.*;
+import java.util.*;
+
 public interface WorkerExecutable {
 
     WorkResponse execute(WorkRequest request);
@@ -17,17 +20,95 @@ public interface WorkerExecutable {
 
         @Override
         public WorkResponse execute(WorkRequest request) {
-            String[] arguments = new String[request.arguments.size()];
-            request.arguments.toArray(arguments);
+            boolean shouldRunAsTestTarget = request.arguments.contains("--run-as-test-target");
+            String executionResultOutputPath = getExecutionResultOutputPath(request.arguments);
 
-            ExecutableResult result = executable.execute(arguments);
+            List<String> detektArgs = sanitizeDetektArguments(request.arguments);
+
+            ExecutableResult result = executable.execute(detektArgs.toArray(new String[0]));
 
             WorkResponse response = new WorkResponse();
             response.requestId = request.requestId;
             response.output = result.output();
             response.exitCode = result.statusCode();
 
+            writeExecutionResultToFile(response.exitCode, executionResultOutputPath);
+
+            if (shouldRunAsTestTarget) {
+                response.exitCode = 0;
+            }
+
             return response;
+        }
+
+        /**
+         * Writes the execution result to a file
+         */
+        private static void writeExecutionResultToFile(Integer exitCode, String executionResultOutputPath) {
+            try (BufferedWriter writer = new BufferedWriter(new FileWriter(executionResultOutputPath))) {
+                writer.write(String.format("#!/bin/bash\n\nexit %d\n", exitCode));
+            } catch (IOException e) {
+                e.printStackTrace();
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static List<String> sanitizeDetektArguments(List<String> inputArgs) {
+            Set<String> excludeArgs = new HashSet<>(Arrays.asList("--execution-result", "--run-as-test-target"));
+            return filterOutArgValuePairs(inputArgs, excludeArgs);
+        }
+
+        /**
+         * Retrieves the output path for the test result from the input arguments.
+         */
+        private static String getExecutionResultOutputPath(List<String> inputArgs) {
+            String outputPath = getArgument(inputArgs, "--execution-result");
+            if (outputPath == null) {
+                System.err.println("File path for execution-result was not set");
+                System.exit(1);
+            }
+            return outputPath;
+        }
+
+        /**
+         * Filters out specified arguments and their corresponding values from the input argument list.
+         */
+        public static List<String> filterOutArgValuePairs(List<String> args, Set<String> excludeArgs) {
+            List<String> filteredList = new ArrayList<>();
+
+            int index = 0;
+
+            while (index < args.size()) {
+                String value = args.get(index);
+                if (!excludeArgs.contains(value)) {
+                    filteredList.add(value);
+                } else {
+                    if (!args.get(index + 1).startsWith("--")) {
+                        // Skip the arg-value pair since matching argument was found
+                        index += 1;
+                    }
+                }
+                index += 1;
+            }
+
+            return filteredList;
+        }
+
+        /**
+         * Retrieves the value associated with the given argument name from the input arguments list.
+         *
+         * @param inputArgs List of input arguments.
+         * @param argName The name of the argument whose value needs to be fetched.
+         * @return The value associated with the given argument name or null if the argument is not found.
+         */
+        private static String getArgument(List<String> inputArgs, String argName) {
+            try {
+                // Get the index of the argument and return the value at the next index.
+                return inputArgs.get(inputArgs.indexOf(argName) + 1);
+            } catch (IndexOutOfBoundsException ignored) {
+                // Return null if the argument is not found or there's no value after it.
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
- Add `detekt_test` rule which shares implementation with the existing `detekt-build-target`
- Modify detekt-rule implementation
    - Set default attributes that are shared between the `detekt-build-target` & `detekt-test-target`
    - Always write the `execution-result` of detekt to a text file
    - Do not fail detekt execution if `--run-as-test-target` is passed via detekt arguments
        - Running the detekt-test target will fail the execution after it evaluates the `execution-result` that is written to the output file
- Update `OneShot` execution to modify the contents of the `params-file` (if passed-in) to only passthrough detekt-related arguments